### PR TITLE
Update account API paths

### DIFF
--- a/english-quiz-app/src/hooks/useAuth.tsx
+++ b/english-quiz-app/src/hooks/useAuth.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { User, LoginRequest, RegisterRequest } from '@/types';
-import { authApi } from '@/lib/api';
+import { authApiService } from '@/lib/api';
 
 interface AuthContextType {
   user: User | null;
@@ -36,7 +36,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       const token = localStorage.getItem('auth_token');
       if (token) {
         try {
-          const userData = await authApi.getProfile();
+          const userData = await authApiService.getProfile();
           setUser(userData);
         } catch (error) {
           console.error('Failed to get profile:', error);
@@ -51,7 +51,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const login = async (data: LoginRequest) => {
     try {
-      const response = await authApi.login(data);
+      const response = await authApiService.login(data);
       localStorage.setItem('auth_token', response.token);
       setUser(response.user);
     } catch (error) {
@@ -61,7 +61,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const register = async (data: RegisterRequest) => {
     try {
-      const response = await authApi.register(data);
+      const response = await authApiService.register(data);
       localStorage.setItem('auth_token', response.token);
       setUser(response.user);
     } catch (error) {
@@ -71,7 +71,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const logout = async () => {
     try {
-      await authApi.logout();
+      await authApiService.logout();
     } catch (error) {
       console.error('Logout error:', error);
     } finally {
@@ -82,7 +82,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const refreshUser = async () => {
     try {
-      const userData = await authApi.getProfile();
+      const userData = await authApiService.getProfile();
       setUser(userData);
     } catch (error) {
       console.error('Refresh user error:', error);

--- a/english-quiz-app/src/lib/api.ts
+++ b/english-quiz-app/src/lib/api.ts
@@ -14,9 +14,17 @@ import {
 } from '@/types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api';
+const AUTH_API_BASE_URL = 'http://localhost:7071/fai/v1/account';
 
 const api = axios.create({
   baseURL: API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+const authApi = axios.create({
+  baseURL: AUTH_API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -32,14 +40,14 @@ api.interceptors.request.use((config) => {
 });
 
 // Auth API
-export const authApi = {
+export const authApiService = {
   login: async (data: LoginRequest): Promise<AuthResponse> => {
-    const response = await api.post<ApiResponse<AuthResponse>>('/v1/account/auth', data);
+    const response = await authApi.post<ApiResponse<AuthResponse>>('/auth', data);
     return response.data.data;
   },
 
   register: async (data: RegisterRequest): Promise<AuthResponse> => {
-    const response = await api.post<ApiResponse<AuthResponse>>('/v1/account/register', data);
+    const response = await authApi.post<ApiResponse<AuthResponse>>('/register', data);
     return response.data.data;
   },
 

--- a/english-quiz-app/src/lib/api.ts
+++ b/english-quiz-app/src/lib/api.ts
@@ -34,12 +34,12 @@ api.interceptors.request.use((config) => {
 // Auth API
 export const authApi = {
   login: async (data: LoginRequest): Promise<AuthResponse> => {
-    const response = await api.post<ApiResponse<AuthResponse>>('/auth/login', data);
+    const response = await api.post<ApiResponse<AuthResponse>>('/v1/account/auth', data);
     return response.data.data;
   },
 
   register: async (data: RegisterRequest): Promise<AuthResponse> => {
-    const response = await api.post<ApiResponse<AuthResponse>>('/auth/register', data);
+    const response = await api.post<ApiResponse<AuthResponse>>('/v1/account/register', data);
     return response.data.data;
   },
 


### PR DESCRIPTION
Update login and register API paths to `/v1/account/auth` and `/v1/account/register` respectively, as per new API specifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc7e7d9f-adba-42f2-9ae9-b69c9e985996">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc7e7d9f-adba-42f2-9ae9-b69c9e985996">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

